### PR TITLE
Add convenience MockObjectProvider::mock(Blah::class) method

### DIFF
--- a/src/DependencyInjection/Container.php
+++ b/src/DependencyInjection/Container.php
@@ -98,7 +98,6 @@ class Container {
      */
     public function get($className) {
         return $this->__doGet($className);
-
     }
 
 

--- a/src/Testing/MockObjectProvider.php
+++ b/src/Testing/MockObjectProvider.php
@@ -44,6 +44,15 @@ class MockObjectProvider {
         return Container::instance()->get(MockObjectProvider::class);
     }
 
+    /**
+     * @template T
+     * @psalm-param class-string<T> $className
+     * @return MockObject|T
+     */
+    public static function mock(string $className) {
+        return MockObjectProvider::instance()->getMockInstance($className);
+    }
+
 
     /**
      * Get a mock instance for a given class name


### PR DESCRIPTION
Saves us some characters when doing. Wanted to sand down some rough edges around testing.

`$mockBlah = MockObjectProvider::instance->getMockInstance(Blah::class);`

`$mockBlah = MockObjectProvider::mock(Blah::class);`
