### PR TITLE
Fix StringUtils deprecation warning

### DIFF
--- a/src/Util/StringUtils.php
+++ b/src/Util/StringUtils.php
@@ -128,7 +128,7 @@ class StringUtils {
      * @param int $depth
      * @return string
      */
-    public static function trim(string $string, string $characters = " \t\n\r\0\x0B", int $depth = null): string {
+    public static function trim(string $string, string $characters = " \t\n\r\0\x0B", ?int $depth = null): string {
 
         if (!$depth) {
             return trim($string, $characters);


### PR DESCRIPTION
Mark $depth as nullable on trim() method