### PR TITLE
lock google/cloud-logging version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "amphp/socket": "*",
     "amphp/http": "*",
     "amphp/http-client": "*",
-    "google/cloud-logging": "*",
+    "google/cloud-logging": "^1.30.0",
     "google/appengine-php-sdk": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Keep google/cloud-logging at version ^1.30.x as 2.x.x introduces breakages